### PR TITLE
fix links to maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,31 +68,31 @@
                 <h1>Introduction to D3.js Web Mapping Through 7 Simple Maps</h1>
                 <p>Listed below are the seven example maps from Rich Donohue's introductory lesson on D3.js, presented at the June meetup of maptimeLEX. You can follow along with the <a href="https://github.com/maptimelex/d3-mapping/blob/master/README.md" target="_blank">presentation on GitHub</a> to create the maps listed below.</p>
                 <div class="list-group">
-                  <a href="/d3-map01-starter" class="list-group-item">
+                  <a href="d3-mapping/d3-map01-starter" class="list-group-item">
                     <h4 class="list-group-item-heading">1. A very simple D3 map</h4>
                     <!-- <p class="list-group-item-text">...</p> -->
                   </a>
-                  <a href="/d3-map02-interaction" class="list-group-item">
+                  <a href="d3-mapping/d3-map02-interaction" class="list-group-item">
                     <h4 class="list-group-item-heading">2. A D3 map with basic interaction</h4>
                     <!-- <p class="list-group-item-text">...</p> -->
                   </a>
-                  <a href="/d3-map03-queue" class="list-group-item">
+                  <a href="d3-mapping/d3-map03-queue" class="list-group-item">
                     <h4 class="list-group-item-heading">3. A D3 map using queue.js</h4>
                     <!-- <p class="list-group-item-text">...</p> -->
                   </a>
-                  <a href="/d3-map04-topojson" class="list-group-item">
+                  <a href="d3-mapping/d3-map04-topojson" class="list-group-item">
                     <h4 class="list-group-item-heading">4. A D3 map using topojson</h4>
                     <!-- <p class="list-group-item-text">...</p> -->
                   </a>
-                  <a href="d3-map05-data-point" class="list-group-item">
+                  <a href="d3-mapping/d3-map05-data-point" class="list-group-item">
                     <h4 class="list-group-item-heading">5. A D3 map plotting oil and gas well points</h4>
                     <!-- <p class="list-group-item-text">...</p> -->
                   </a>
-                  <a href="/d3-map06-data-area" class="list-group-item">
+                  <a href="d3-mapping/d3-map06-data-area" class="list-group-item">
                     <h4 class="list-group-item-heading">6. A D3 county choropleth map of Kentucky oil or gas wells</h4>
                     <!-- <p class="list-group-item-text">...</p> -->
                   </a>
-                  <a href="d3-map07-data-area-toggle" class="list-group-item">
+                  <a href="d3-mapping/d3-map07-data-area-toggle" class="list-group-item">
                     <h4 class="list-group-item-heading">7. A toggle D3 county map of Kentucky oil and gas wells</h4>
                     <!-- <p class="list-group-item-text">...</p> -->
                   </a>


### PR DESCRIPTION
I must have messed up the relative paths to the child directories.
Anyway, clicking the links before was going to
maptimelex.github.io/d3-whatever-example rather than that directory
within d3-mapping
