### PR TITLE
Use SVG transform instead of cx and cy attributes

### DIFF
--- a/d3-map05-data-point/index.html
+++ b/d3-map05-data-point/index.html
@@ -69,11 +69,8 @@
             .data(wells)
             .enter()
             .append("circle")
-            .attr("cx", function(d){
-                return projection([d["X"], d["Y"] ])[0];
-            })
-            .attr("cy", function(d){
-                return projection([d["X"], d["Y"] ])[1];
+            .attr("transform", function(d) {
+            	return "translate(" + projection([d.X, d.Y]) + ")";
             })
             .attr("r", 1)
             .style("stroke","none")


### PR DESCRIPTION
This is a suggestion that should (possibly, dramatically) speed up rendering of the oil wells example. Rather than projecting the point twice and setting two separate attributes, you can just set the transform attribute and translate it by the projected offset. An alternative to this would be something like this, e.g. if you needed to also transform the element separately:

``` js
.attr("cx", function(d) {
  d.position = projection([d.X, d.Y]);
  return d.position[0];
})
.attr("cy", function(d) {
  return d.position[1];
})
```

In other words: store the projected point and reference it as-is in the `cy` call.

Also, using the dot notation (`d.X` instead of `d["X"]`) saves some tedious typing.
